### PR TITLE
A possible solution to issue #8 (print plots automatically)

### DIFF
--- a/R/reprex.R
+++ b/R/reprex.R
@@ -28,7 +28,10 @@
 #' @export
 reprex <- function(x = NULL, slug = "REPREX", venue = c("gh", "so"),
                    outfiles = NULL) {
-
+  
+  ### Set image upload to imgur
+  knitr::opts_knit$set(upload.fun = knitr::imgur_upload, base.url = NULL)
+  
   venue <- match.arg(venue)
 
   the_source <- if(is.null(x)) cb_read() else readLines(x)


### PR DESCRIPTION
It sets knitr to upload to imugr , the final .md file includes the link automatically.
An example generated with this only change in the function.
``` r
plot(1:100)
```

![](http://i.imgur.com/dy8XUiR.png)

``` r

a <- c(1,2)
```