### PR TITLE
Clear clip

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -14,7 +14,7 @@ VignetteBuilder: knitr
 URL: https://github.com/jennybc/reprex
 BugReports: https://github.com/jennybc/reprex/issues
 Imports:
-    clipr,
+    clipr (>= 0.2.0),
     rmarkdown,
     stringr
 Suggests:

--- a/R/clipboard.R
+++ b/R/clipboard.R
@@ -1,6 +1,0 @@
-## this file and function will go away once clipr offers this
-## it's just useful to have during development and in tests
-
-cb_clear <- function() {
-  system("pbcopy < /dev/null")
-}

--- a/tests/testthat/test-reprex.R
+++ b/tests/testthat/test-reprex.R
@@ -10,7 +10,7 @@ test_that("Writing to, reading from, and clearing the clipboard work", {
   clipr::write_clip("test clipboard string")
   expect_equal(clipr::read_clip(), "test clipboard string")
 
-  cb_clear()
+  clipr::clear_clip()
   expect_warning(ret <- clipr::read_clip())
   expect_equal(length(ret), 0)
 })


### PR DESCRIPTION
clipr 0.2.0 is now on CRAN, and it implements a `clear_clip()` function :clipboard: 
