### PR TITLE
Fix UTF-8-related problem on Windows

### DIFF
--- a/R/reprex.R
+++ b/R/reprex.R
@@ -255,7 +255,7 @@ reprex <- function(
     lns <- lns[line_info != "bt"]
     output_lines <- lns
     output_file <- gsub("_reprex", "_rendered", r_file)
-    writeLines(output_lines, file(output_file, encoding = "UTF-8"))
+    writeLines(output_lines, output_file)
     if (outfile_given) {
       message("Writing reprex as commented R script:\n  * ",
               sub(pathstem, "", output_file))

--- a/R/reprex.R
+++ b/R/reprex.R
@@ -246,7 +246,7 @@ reprex <- function(
     pathstem <- path_stem(r_file, md_file)
     message("Writing reprex markdown:\n  * ", sub(pathstem, "", md_file))
   }
-  output_lines <- readLines(md_file)
+  output_lines <- readLines(md_file, encoding = "UTF-8")
 
   if (identical(venue, "r")) {
     lns <- output_lines
@@ -255,7 +255,7 @@ reprex <- function(
     lns <- lns[line_info != "bt"]
     output_lines <- lns
     output_file <- gsub("_reprex", "_rendered", r_file)
-    writeLines(output_lines, output_file)
+    writeLines(output_lines, file(output_file, encoding = "UTF-8"))
     if (outfile_given) {
       message("Writing reprex as commented R script:\n  * ",
               sub(pathstem, "", output_file))
@@ -281,12 +281,12 @@ reprex <- function(
     ## `clean = FALSE` does too much (deletes foo_reprex_files, which might
     ## hold local figs)
     if (is.null(outfile)) {
-      html_file <- rmarkdown::render(md_file, quiet = TRUE)
+      html_file <- rmarkdown::render(md_file, quiet = TRUE, encoding = "UTF-8")
     } else {
       html_file <- strip_ext(basename(md_file))
       html_file <- tempfile(pattern = paste0(html_file, "_"), fileext = ".html")
       html_file <-
-        rmarkdown::render(md_file, output_file = html_file, quiet = TRUE)
+        rmarkdown::render(md_file, output_file = html_file, quiet = TRUE, encoding = "UTF-8")
     }
     viewer <- getOption("viewer") %||% utils::browseURL
     viewer(html_file)


### PR DESCRIPTION
On Windows machines where the default locale is not UTF-8, the output of `reprex()` cannot be rendered properly due to Encoding-related issue.

## Problem

An example code is here:

```r
reprex::reprex({
    cat("あ")
})
```

This will be corrupted as bellow:

``` r
cat("縺・)
#> 縺・
```

## Cause and fix

First, `r_file` is written out with native encoding [here](https://github.com/jennybc/reprex/blob/2a7abb9b0dea7606446fd820e6f39d7604da710a/R/reprex.R#L239):

```r
 writeLines(the_source, r_file)
```

Though `the_source` may be encoded with UTF-8 or the native encoding, depending on whether the source is acquired from the argument or the clipboard, `r_file` is in the native encoding anyway. So far, so good.

Then, `r_file` is rendered by `rmarkdown::render()`, which outputs files with UTF-8, [here](https://github.com/jennybc/reprex/blob/2a7abb9b0dea7606446fd820e6f39d7604da710a/R/reprex.R#L244):

```r
  output_file <- md_file <- reprex_(r_file)
```

Since `output_file` and `md_file` is UTF-8. we have to specify `encoding = "UTF-8"` [here](https://github.com/jennybc/reprex/blob/2a7abb9b0dea7606446fd820e6f39d7604da710a/R/reprex.R#L249),

```r
  output_lines <- readLines(md_file)
```

and [here](https://github.com/jennybc/reprex/blob/2a7abb9b0dea7606446fd820e6f39d7604da710a/R/reprex.R#L283-L293):

```r
    if (is.null(outfile)) {
      html_file <- rmarkdown::render(md_file, quiet = TRUE)
    } else {
      html_file <- strip_ext(basename(md_file))
      html_file <- tempfile(pattern = paste0(html_file, "_"), fileext = ".html")
      html_file <-
        rmarkdown::render(md_file, output_file = html_file, quiet = TRUE)
}
```

Additionally, I wonder we should also add `encoding` [here](https://github.com/jennybc/reprex/blob/2a7abb9b0dea7606446fd820e6f39d7604da710a/R/reprex.R#L258), but I'm not really sure that the output R script should be always with UTF-8.

```r
 writeLines(output_lines, output_file)
```