### PR TITLE
Error sooner when clipboard not available, and provide suggestion

### DIFF
--- a/R/utils-io.R
+++ b/R/utils-io.R
@@ -37,10 +37,9 @@ locate_input <- function(input) {
       c(
         "No input provided and clipboard is not available.",
         i = "
-        Install a clipboard tool for your system or
-        provide code via the {.arg x} or {.arg input} argument.",
-        i = "
-        Call {.fun clipr::dr_clipr} for clipboard troubleshooting advice."
+        Run {.run clipr::dr_clipr()} for clipboard troubleshooting
+        advice or provide code via the {.arg x} or {.arg input}
+        argument."
       ),
       call = quote(reprex())
     )

--- a/R/utils-io.R
+++ b/R/utils-io.R
@@ -33,14 +33,17 @@ locate_input <- function(input) {
     if (in_rstudio()) {
       return("selection")
     }
-    cli::cli_abort(c(
-      "No input provided and clipboard is not available.",
-      i = "
+    cli::cli_abort(
+      c(
+        "No input provided and clipboard is not available.",
+        i = "
         Install a clipboard tool for your system or
         provide code via the {.arg x} or {.arg input} argument.",
-      i = "
+        i = "
         Call {.fun clipr::dr_clipr} for clipboard troubleshooting advice."
-    ))
+      ),
+      call = quote(reprex())
+    )
   }
 
   if (is_path(input)) {

--- a/R/utils-io.R
+++ b/R/utils-io.R
@@ -35,7 +35,7 @@ locate_input <- function(input) {
     }
     cli::cli_abort(
       c(
-        "No input provided and clipboard is not available.",
+        "Clipboard is not available and no input provided.",
         i = "
         Run {.run clipr::dr_clipr()} for clipboard troubleshooting
         advice or provide code via the {.arg x} or {.arg input}

--- a/R/utils-io.R
+++ b/R/utils-io.R
@@ -30,7 +30,7 @@ locate_input <- function(input) {
     if (reprex_clipboard()) {
       return("clipboard")
     }
-    if (in_rstudio()) {
+    if (in_rstudio() || in_positron()) {
       return("selection")
     }
     cli::cli_abort(

--- a/R/utils-io.R
+++ b/R/utils-io.R
@@ -32,9 +32,15 @@ locate_input <- function(input) {
     }
     if (in_rstudio()) {
       return("selection")
-    } else {
-      return(NULL)
     }
+    cli::cli_abort(c(
+      "No input provided and clipboard is not available.",
+      i = "
+        Install a clipboard tool for your system or
+        provide code via the {.arg x} or {.arg input} argument.",
+      i = "
+        Call {.fun clipr::dr_clipr} for clipboard troubleshooting advice."
+    ))
   }
 
   if (is_path(input)) {

--- a/R/utils.R
+++ b/R/utils.R
@@ -20,6 +20,10 @@ in_rstudio <- function() {
   .Platform$GUI == "RStudio"
 }
 
+in_positron <- function() {
+  .Platform$GUI == "Positron"
+}
+
 trim_ws <- function(x) {
   sub("\\s*$", "", sub("^\\s*", "", x))
 }

--- a/tests/testthat/_snaps/utils.md
+++ b/tests/testthat/_snaps/utils.md
@@ -1,0 +1,9 @@
+# locate_input() works
+
+    Code
+      locate_input(NULL)
+    Condition
+      Error in `reprex()`:
+      ! Clipboard is not available and no input provided.
+      i Run `clipr::dr_clipr()` for clipboard troubleshooting advice or provide code via the `x` or `input` argument.
+

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -11,7 +11,7 @@ test_that("locate_input() works", {
   with_mocked_bindings(
     reprex_clipboard = function() FALSE,
     in_rstudio = function() FALSE,
-    expect_null(locate_input(NULL))
+    expect_snapshot(locate_input(NULL), error = TRUE)
   )
   expect_identical("path", locate_input(path_temp()))
   expect_identical("input", locate_input(c("a", "b")))

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -11,6 +11,7 @@ test_that("locate_input() works", {
   with_mocked_bindings(
     reprex_clipboard = function() FALSE,
     in_rstudio = function() FALSE,
+    in_positron = function() FALSE,
     expect_snapshot(locate_input(NULL), error = TRUE)
   )
   expect_identical("path", locate_input(path_temp()))


### PR DESCRIPTION
I had been "stuck" with `reprex::reprex()` not working for me on Positron since I moved over from RStudio. 

The relevant error message was right there in front of me (I'm on Linux, just gotta install some clipboard library, which is how I resolved it in the end), but it took me a while to realise it was there.  When skim-reading error messages, I tend to go straight to the most recent one, and so I missed it.

Before:
```r
> reprex::reprex()                                                                                                         
  Clipboard on X11 requires 'xclip' (recommended) or 'xsel'; Clipboard on Wayland requires 'wl-copy' and 'wl-paste'.         
  Error in `switch()`:                                                                                                       
  ! EXPR must be a length 1 vector
```

The source of the `switch()` error, as described by Claude:

> `reprex()` calls `locate_input(NULL)` to figure out where to get the code from. It checks clipboard (no — tools not installed), then checks RStudio (no — we're in Positron). With both options exhausted, it returns `NULL`. Back in `reprex_impl()`, that  `NULL` gets passed to `switch(where, ...)` on line 50, but `switch()` requires a length-1 string — so it throws `"EXPR must be a   length 1 vector"` instead of anything useful about the actual problem (no input source available).


This PR surfaces things a little more easily by erroring sooner and drawing the user's attention to the source of the issue instead.

After:

```r
> reprex::reprex()
Clipboard on X11 requires 'xclip' (recommended) or 'xsel'; Clipboard on Wayland requires 'wl-copy' and 'wl-paste'.
Error in `reprex()`:
! No input provided and clipboard is not available.
ℹ Run clipr::dr_clipr() for clipboard troubleshooting advice or provide code via the `x` or `input` argument.
Show Traceback
```